### PR TITLE
update es settings to fit circleci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-FROM elasticsearch:5
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.1
+
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+
+USER root
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 
 RUN elasticsearch-plugin install analysis-kuromoji
 RUN elasticsearch-plugin install analysis-icu
 RUN elasticsearch-plugin install mapper-attachments
 
-EXPOSE 9200
-CMD ["elasticsearch"]
+# elasticsearch cannot be executed by 'root' user for security reasons
+# Details: https://discuss.elastic.co/t/why-is-it-elasticsearch-is-not-allowed-to-run-as-root/60413
+USER elasticsearch
+
+ENV _JAVA_OPTIONS="-Xmx512m -Xms512m"

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,0 +1,26 @@
+cluster.name: "docker-ci-cluster"
+
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# because a single node is enough for CI build
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 1
+
+# Disable X-Packs Security
+# because it requires BASE authentication which is redundant for test
+# Details: https://www.elastic.co/guide/en/x-pack/current/security-settings.html#general-security-settings
+xpack.security.enabled: false
+
+# https://www.elastic.co/guide/en/elasticsearch/guide/current/_limiting_memory_usage.html#fielddata-size
+# Place an upper limit to the fielddata cache to avoid OOM
+indices.fielddata.cache.size: 40%
+# Checks to see whether the query size is too large before data is loaded
+indices.breaker.fielddata.limit: 50%
+
+# run docker for development use
+#   https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-dev-mode
+# here is why to set 'http.host' and 'transport.host' instead of 'network.host'
+#   https://www.elastic.co/guide/en/elasticsearch/reference/5.3/bootstrap-checks.html#_development_vs_production_mode
+http.host: 0.0.0.0
+transport.host: 127.0.0.1
+


### PR DESCRIPTION
update elastic search settings to fit circle ci environment.
Its container has only 4GB memory, so we have to save memory usages for es.